### PR TITLE
chore: license, new go.mod url

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 ssg authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ ssg/
 ## Description of the directory structure
 
 - The markdown content for the site is stored in content/. It can contain subdirectories as the folder is recursively rendered
-- Static assets such as images and fonts are stores in static/
+- Static assets such as images and fonts are stored in static/
 - The layout of the site is configured using html files in layout/
 
    - The 'config.yml' file stores the configuration of the site and includes details such as the baseURL

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/anirudhsudhir/ssg
+module github.com/acmpesuecc/ssg
 
 go 1.22.0
 

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/anirudhsudhir/ssg/cmd/ssg"
+	"github.com/acmpesuecc/ssg/cmd/ssg"
 )
 
 func main() {


### PR DESCRIPTION
Add LICENSE file
Use migrated go.mod path 