### PR TITLE
(merge) feat: implement drafts

### DIFF
--- a/cmd/ssg/utils.go
+++ b/cmd/ssg/utils.go
@@ -48,38 +48,6 @@ func (g *Generator) copyFiles(srcPath string, destPath string) {
 	}
 }
 
-// func tion get an unmarshaled Layoutconfig
-// func (g *Generator) ymlUnmarshaledConfig() LayoutConfig {
-// 	configFile, err := os.ReadFile("layout/config.yml")
-// 	if err != nil {
-// 		g.ErrorLogger.Fatal(err)
-// 	}
-
-// 	var config LayoutConfig
-// 	if err = yaml.Unmarshal(configFile, &config); err != nil {
-// 		g.ErrorLogger.Fatal(err)
-// 	}
-
-// 	return config
-// }
-//
-// func (g *Generator) ymlConfigUpdater(config LayoutConfig) {
-// 	marshaledConfig, err := yaml.Marshal(&config)
-// 	if err != nil {
-// 		g.ErrorLogger.Fatal(err)
-// 	}
-
-// 	if err = os.WriteFile("layout/config.yml", marshaledConfig, 0666); err != nil {
-// 		g.ErrorLogger.Fatal(err)
-// 	}
-// }
-
-// func (g *Generator) configExtend(filenameWithoutExtension string) {
-// 	config := g.ymlUnmarshaledConfig()
-
-// 	g.ymlConfigUpdater(config)
-// }
-
 func (g *Generator) readMdDir(dirPath string) {
 	// Listing all files in the dirPath directory
 	dirEntries, err := os.ReadDir(dirPath)
@@ -110,7 +78,7 @@ func (g *Generator) readMdDir(dirPath string) {
 	}
 
 	// Reading the markdown files into memory
-	for _, filepath := range g.mdFilesPath {
+	for i, filepath := range g.mdFilesPath {
 		content, err := os.ReadFile(filepath)
 		if err != nil {
 			g.ErrorLogger.Fatal(err)
@@ -119,11 +87,12 @@ func (g *Generator) readMdDir(dirPath string) {
 		frontmatter, body := g.parseMarkdownContent(string(content))
 
 		page := Page{
+            Filename:    strings.Split(g.mdFilesName[i], ".")[0],
 			Frontmatter: frontmatter,
 			Body:        template.HTML(body),
 			Layout:      g.LayoutConfig,
 		}
 
-		g.mdParsed = append(g.mdParsed, page)
-	}
+        g.mdParsed = append(g.mdParsed, page) 
+    }
 }

--- a/content/index.md
+++ b/content/index.md
@@ -3,7 +3,7 @@ date: 24-02-2024
 title: Home
 ---
 
-### Hi, I'm Anirudh!
+### Henlo!
 A computer science student and tech enthusiast. Welcome to my home on the internet.
 
 ![demo-image](static/plane.jpg)

--- a/content/posts/hello.md
+++ b/content/posts/hello.md
@@ -1,6 +1,7 @@
 ---
 date: 23-11-2023
-title:
+title: Git Set Go!
+draft: true
 ---
 
 # Introduction

--- a/content/posts/qapture.md
+++ b/content/posts/qapture.md
@@ -1,6 +1,7 @@
 ---
 date: 23-11-2023
 title: Qapture
+draft: false
 ---
 
 This post is part of a talk I gave at the Mentor Expo conducted by [HSP](https://homebrew.hsp-ec.xyz), the developer community at my college.

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 func main() {
 	var serve bool
 	var addr string
+    var draft bool
 
 	rootCmd := &cobra.Command{
 		Use:   "ssg",
@@ -19,6 +20,9 @@ func main() {
 			generator := ssg.Generator{
 				ErrorLogger: log.New(os.Stderr, "ERROR\t", log.Ldate|log.Ltime|log.Lshortfile),
 			}
+            if draft { 
+                generator.Draft = true
+            }
 			generator.RenderSite(addr)
 
 			if serve {
@@ -29,6 +33,7 @@ func main() {
 
 	rootCmd.Flags().BoolVarP(&serve, "serve", "s", false, "serve the rendered content")
 	rootCmd.Flags().StringVarP(&addr, "addr", "a", "8000", "ip address to serve rendered content to")
+	rootCmd.Flags().BoolVarP(&draft, "draft", "d", false, "renders draft posts")
 
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Create following fields for the structs:
- `Frontmatter` now contains `Draft`
- `Page`  contains `Filename` 
- `Generator` contains `mdNonDrafts` and `Draft`

Created a `draftChecker()` function that appends draft files when `draft` flag. If  we aren't querying for draft files, `mdPosts` is copied into `mdNonDrafts`