### PR TITLE
meta: add dummy robots.txt for now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,12 +42,9 @@ jobs:
     - name: Build site with ssg
       run: |
         ./ssg
-   
-    - name: Setup Pages
-      uses: actions/configure-pages@v4
-
+        
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-artifact@master
       with:
         path: 'rendered'
         if-no-files-found: error
@@ -55,11 +52,22 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
+    
     environment:
       name: github-pages
       url: ${{steps.deployment.outputs.page_url}}
-
     steps:
+    - name: Download rendered
+      uses: actions/download-artifact@master
+
+    - name: Setup Pages
+      uses: actions/configure-pages@v4
+
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: 'artifact'
+
     - name: Deploy to GitHub Pages
       id: deployment
       uses: actions/deploy-pages@v4

--- a/cmd/ssg/main.go
+++ b/cmd/ssg/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"regexp"
+//	"regexp"
 	"slices"
 	"strings"
 
@@ -186,8 +186,6 @@ func (g *Generator) parseMarkdownContent(filecontent string) (Frontmatter, strin
 		markdown = filecontent
 	}
 
-	g.generateAbsoluteStaticLinks(&markdown)
-
 	// Parsing markdown to HTML
 	var parsedMarkdown bytes.Buffer
 	if err := goldmark.Convert([]byte(markdown), &parsedMarkdown); err != nil {
@@ -215,12 +213,13 @@ func (g *Generator) parseConfig() {
 	}
 }
 
-// Make links to static assets absolute
+/* // Make links to static assets load from root dir /
 func (g *Generator) generateAbsoluteStaticLinks(mdBody *string) {
 	re := regexp.MustCompile(`static\/`)
-	absLink := g.LayoutConfig.BaseURL + "/" + "static/"
+	absLink := "/" + "static/"
 	*mdBody = re.ReplaceAllString(*mdBody, absLink)
 }
+*/
 
 // Parse all the ".html" layout files in the layout/ directory
 func (g *Generator) parseLayoutFiles() *template.Template {

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /
+


### PR DESCRIPTION
- This PR fixes the deploy publish dir.
- The site can now be deployed on a vanilla `username.github.io` page, if it isn't [already](https://acmpesuecc.github.io/) used.